### PR TITLE
DatatypeContexts, WebSocketsData, resolver

### DIFF
--- a/src/Network/Discord/Framework.hs
+++ b/src/Network/Discord/Framework.hs
@@ -1,9 +1,12 @@
 -- | Provides a convenience framework for writing Discord bots without dealing with Pipes
 module Network.Discord.Framework where
   import Control.Concurrent
-  import Control.Monad.Writer
+  import Control.Monad.Writer (tell, execWriter, Writer)
   import Data.Proxy
 
+  import Control.Monad(void)
+  import Control.Monad.IO.Class(liftIO)
+  import Data.Semigroup(Semigroup, (<>))
   import Control.Concurrent.STM
   import Control.Monad.State (get)
   import Data.Aeson (Object)
@@ -61,7 +64,7 @@ module Network.Discord.Framework where
 
   -- | Event handlers for 'Gateway' events. These correspond to events listed in
   --   'Event'
-  data D.Client c => Handle c = Null
+  data               Handle c = Null
                               | Misc                         (Event   -> Effect DiscordM ())
                               | ReadyEvent                   (Init    -> Effect DiscordM ())
                               | ResumedEvent                 (Object  -> Effect DiscordM ())

--- a/src/Network/Discord/Types/Gateway.hs
+++ b/src/Network/Discord/Types/Gateway.hs
@@ -114,6 +114,10 @@ module Network.Discord.Types.Gateway where
     toJSON _ = object []
 
   instance WebSocketsData Payload where
+    fromDataMessage dm =
+      case dm of
+        Text bs _ -> fromLazyByteString bs
+        Binary bs -> fromLazyByteString bs
     fromLazyByteString bs = case eitherDecode bs of
         Right payload -> payload
         Left  reason  -> ParseError reason

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 extra-package-dbs: []
 packages:
 - '.'
-resolver: lts-10.3
+resolver: lts-10.7
 nix:
   packages: [zlib]
 #  shell-file: shell.nix


### PR DESCRIPTION
- removes pointless datatypecontexts pragma
- adds missing WebSocketsData method
- update stack resolver to 10.7 (just happens to be what i'm using, should probably be something later)